### PR TITLE
WIP Allow attaching scroll data hook to any element

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,20 +28,20 @@ const INITIAL_DATA = {
   }
 };
 
-function hasOwnProp(obj: Object, prop: string) {
+function hasProp(obj: Object, prop: string) {
   if (typeof obj === 'undefined' || obj === null) return false;
-  return Object.hasOwnProperty.call(obj, prop);
+  return prop in obj
 }
 
 function getPositionX(elem: Window | HTMLElement) {
-  if (hasOwnProp(elem, 'pageXOffset')) return elem.pageXOffset;
-  if (hasOwnProp(elem, 'scrollLeft')) return elem.scrollLeft;
+  if (hasProp(elem, 'pageXOffset')) return elem.pageXOffset;
+  if (hasProp(elem, 'scrollLeft')) return elem.scrollLeft;
   return 0
 }
 
 function getPositionY(elem: Window | HTMLElement) {
-  if (hasOwnProp(elem, 'pageYOffset')) return elem.pageYOffset;
-  if (hasOwnProp(elem, 'scrollTop')) return elem.scrollTop;
+  if (hasProp(elem, 'pageYOffset')) return elem.pageYOffset;
+  if (hasProp(elem, 'scrollTop')) return elem.scrollTop;
   return 0
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,12 +28,12 @@ const INITIAL_DATA = {
   }
 };
 
-function getPositionX() {
-  return window.pageXOffset || 0;
+function getPositionX(elem = { scrollLeft: 0 }) {
+  return elem.scrollLeft || 0;
 }
 
-function getPositionY() {
-  return window.pageYOffset || 0;
+function getPositionY(elem = { scrollTop: 0 }) {
+  return elem.scrollTop || 0;
 }
 
 function getDirectionX(x: number, frameValues: ScrollDataType): string | null {
@@ -64,7 +64,7 @@ function getRelativeDistanceY(y: number, startValues: ScrollDataType): number {
   return Math.abs(y - startValues.position.y);
 }
 
-export const useScrollData = (options: OptionsType = {}): ScrollDataType => {
+export const useScrollData = (options: OptionsType = { }): ScrollDataType => {
   const [data, setData] = React.useState<ScrollDataType>(INITIAL_DATA);
   const startValues = React.useRef<ScrollDataType>(INITIAL_DATA);
   const frameValues = React.useRef<ScrollDataType>(INITIAL_DATA);
@@ -81,8 +81,8 @@ export const useScrollData = (options: OptionsType = {}): ScrollDataType => {
 
     // Set new position values
     const position = {
-      x: getPositionX(),
-      y: getPositionY()
+      x: getPositionX(options.ref.current),
+      y: getPositionY(options.ref.current)
     };
 
     // Set new direction values
@@ -206,15 +206,18 @@ export const useScrollData = (options: OptionsType = {}): ScrollDataType => {
   }
 
   React.useEffect(() => {
+    if (!options.ref.current) {
+      return;
+    }
     // Add scrollListener
-    window.addEventListener("scroll", onScroll, true);
+    options.ref.current.addEventListener("scroll", onScroll, true);
 
     // Remove listener when unmounting
     return () => {
       clearTimeout(scrollTimeout.current);
-      window.removeEventListener("scroll", onScroll, true);
+      options.ref.current.removeEventListener("scroll", onScroll, true);
     };
-  }, []);
+  }, [options.ref]);
 
   // Return data with rounded values
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,5 +23,5 @@ export type ScrollDataType = {
 export type OptionsType = {
   onScrollStart?: Function;
   onScrollEnd?: Function;
-  ref: RefObject<HTMLElement>;
+  ref?: RefObject<HTMLElement>;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { RefObject } from 'react'
+
 export type DirectionType = {
   x: string | null;
   y: string | null;
@@ -21,4 +23,5 @@ export type ScrollDataType = {
 export type OptionsType = {
   onScrollStart?: Function;
   onScrollEnd?: Function;
+  ref: RefObject<HTMLElement>;
 };


### PR DESCRIPTION
@dejorrit This is extremely useful and solved some tricky scroll behaviour I was struggling with, so kudos for creating this hook. The one thing is that I have to modify the hook slightly for my use-case because I need to attach to a DOM element instead of the window. From initial quick tests it works with pretty minimal changes to accept a ref instead of assuming the `window`. I'd rather submit back to this project than permanently forking if possible so I'm wondering if you're open to supporting this option? My proposal would be to add an optional `ref` in the config. If it's not provided than behaviour would remain unchanged but if it is provided then the scroll data would be collected from the provided element instead. This draft doesn't have the config option, it's just a proof of what changes would be required to handle DOM elements instead of the `window`.